### PR TITLE
Mails fix

### DIFF
--- a/_beam_team/team.md
+++ b/_beam_team/team.md
@@ -92,7 +92,7 @@ members:
     organization: data Artisans
     roles: committer, PPMC
     time_zone: "+1"
-  - name: Stephan Ewen
+  - name: Tom White
     apache_id:
     email: tom@cloudera.com
     organization: Cloudera

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -27,7 +27,7 @@ The team is comprised of Members and Contributors. Members have direct access to
         <tr>
           <th scope="row">{{ member.name }}</th>
           <td scope="row">{{ member.apache_id }}</td>
-          <td scope="row"><a href="mailto:{{ "member.email" }}">{{ member.email }}</a></td>
+          <td scope="row"><a href="mailto:{{ member.email }}">{{ member.email }}</a></td>
           <td scope="row">{{ member.organization }}</td>
           <td scope="row">{{ member.roles }}</td>
           <td scope="row">{{ member.time_zone }}</td>


### PR DESCRIPTION
Fixes for duplicated Stephan Ewen (I guess that's Tom White address) and broken `mailto` link.